### PR TITLE
Saves entire experiment when logging

### DIFF
--- a/torch_tools/data.py
+++ b/torch_tools/data.py
@@ -45,6 +45,8 @@ class TrainValLoader:
         self.batch_size = batch_size
         self.fraction_val = fraction_val
         self.seed = seed
+        self.num_workers = num_workers
+        self.dataset = type(dataset)
 
         if fraction_val > 0.0:
             dataset_size = len(dataset)


### PR DESCRIPTION
Fixes previous issues that arose when trying to pickle the entire experiment for logging. This saves all params except for those that generated the dataset. The additional method for saving data params is not ideal and could be improved.